### PR TITLE
Fix 23 Merge K Sorted Lists Solution

### DIFF
--- a/Heap/23-MergekSortedLists/README.md
+++ b/Heap/23-MergekSortedLists/README.md
@@ -28,7 +28,7 @@ def mergeKLists(lists: List[Optional[ListNode]]) -> Optional[ListNode]:
         current.next = current = node
         if node.next:
             next_node = node.next
-            heappush(heap, (current.val, id(next_node), next_node))
+            heappush(heap, (next_node.val, id(next_node), next_node))
 
     return dummy_head.next
 ```

--- a/Heap/23-MergekSortedLists/solution.py
+++ b/Heap/23-MergekSortedLists/solution.py
@@ -25,6 +25,6 @@ class Solution:
             current.next = current = node
             if node.next:
                 next_node = node.next
-                heappush(heap, (current.val, id(next_node), next_node))
+                heappush(heap, (next_node.val, id(next_node), next_node))
 
         return dummy_head.next


### PR DESCRIPTION
With the same test case in [leetcode](https://leetcode.com/problems/merge-k-sorted-lists/), e.g
```python
test_case = [ListNode(1, ListNode(4, ListNode(5))), ListNode(1, ListNode(3, ListNode(4))), ListNode(2, ListNode(6))]
```
the current solution returns the order as: `[1, 4, 1, 3, 2, 6, 4, 5]`. This PR fixes it so it is sorted correctly.